### PR TITLE
CentOS 7 verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,17 @@ you can start to install the LightVerifier tools.
 ### Manually setting up the verifier's measurementDB
 
 Choose a trusted and secure server for deploying the verifier. 
-Install the dependencies:
+Install the dependencies for Debian:
 
 ```bash
-$ apt-get install redis-server redis-tools debmirror parallel
+$ apt-get install redis-server redis-tools debmirror parallel rpm2cpio
 ```
 
 The measurementDB currently supports the creation of reference 
 measurements for a few Linux distributions, including:
 * Debian
 * Ubuntu 
+* CentOS 7
 
 It would be nice to support a few LTS distributions, including 
 RH-like distributions like CentOS. Pull requests are welcome. 
@@ -81,8 +82,8 @@ The current default is Debian. To change this to another distro, change the
 
 If you haven't already, then enable the TPM in the BIOS of the device
 and then take ownership using **tpm_takeownership**.
-Then proceed to make the AIK using the following commands from the
-tpm-quote-tools package:
+Then proceed to make the Attestation Identity Key (AIK)
+using the following commands from the included tpm-quote-tools package:
 
 ```bash
 $ tpm_mkuuid aik.uuid
@@ -130,7 +131,7 @@ If successful, it will generate a file called report.log.
 it waits for a request from the verifier and sends both the log and TPM quote.
 You can run it with:
 ```bash
-$ ./ra-agent.sh <publicAIKcert> <AIKuuid> <port> 10
+$ ./ra-agent.sh <aik.pub> <aik.uuid> <port> 10
 ```
 
 ## How does it work

--- a/measurementDB/buildStore.sh
+++ b/measurementDB/buildStore.sh
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-./downloadDeb.sh
+./downloadPkgs.sh
 
 ./storeHash.sh
 

--- a/measurementDB/downloadPkgs.sh
+++ b/measurementDB/downloadPkgs.sh
@@ -26,15 +26,17 @@ UBUNTU="rsync://archive.ubuntu.com/ubuntu/"
 CENTOS="rsync://anorien.csc.warwick.ac.uk/CentOS/7/"
 
 # Default distro to sync is Debian
-DISTRO=$DEBIAN
+DISTRO=$CENTOS
 
-rsync -aiz --ignore-existing \
+rsync --archive --itemize-changes --compress --ignore-existing \
 	--include="*/" \
 	--include="*i386" \
 	--include="*amd64" \
 	--include="*x86-64*" \
-	--exclude "isos" \
-	--exclude="*" \
+	--include="*x86_64*" \
+	--include="*.deb" \
+	--include="*.rpm" \
+	--exclude "*" \
 	$DISTRO ./packages | egrep '^>' | cut -d " " -f 2 >> scan_files
 
 # Sort the files to be hashed

--- a/measurementDB/downloadPkgs.sh
+++ b/measurementDB/downloadPkgs.sh
@@ -23,19 +23,18 @@ DEBIAN="rsync://ftp.uk.debian.org/debian/"
 UBUNTU="rsync://archive.ubuntu.com/ubuntu/"
 
 # RPM-based distributions, with an example mirror
-CENTOS="rsync://anorien.csc.warwick.ac.uk/CentOS/7/"
+CENTOS7="rsync://anorien.csc.warwick.ac.uk/CentOS/7/"
 
 # Default distro to sync is Debian
-DISTRO=$CENTOS
+DISTRO=$DEBIAN
 
 rsync --archive --itemize-changes --compress --ignore-existing \
 	--include="*/" \
-	--include="*i386" \
-	--include="*amd64" \
-	--include="*x86-64*" \
-	--include="*x86_64*" \
-	--include="*.deb" \
-	--include="*.rpm" \
+	--include="*noarch*" \
+	--include="*i386.deb" \
+	--include="*amd64.deb*" \
+	--include="*x86-64.rpm*" \
+	--include="*x86_64.rpm*" \
 	--exclude "*" \
 	$DISTRO ./packages | egrep '^>' | cut -d " " -f 2 >> scan_files
 

--- a/measurementDB/downloadPkgs.sh
+++ b/measurementDB/downloadPkgs.sh
@@ -18,13 +18,24 @@
 #		Adrian L. Shaw <adrianlshaw@acm.org>
 #
 
+# Debian-based distributions
 DEBIAN="rsync://ftp.uk.debian.org/debian/"
 UBUNTU="rsync://archive.ubuntu.com/ubuntu/"
+
+# RPM-based distributions, with an example mirror
+CENTOS="rsync://anorien.csc.warwick.ac.uk/CentOS/7/"
 
 # Default distro to sync is Debian
 DISTRO=$DEBIAN
 
-rsync -aiz --ignore-existing --include="*/" --include="*i386.deb" --include="*amd64.deb" --exclude="*" $DISTRO ./packages | egrep '^>' | cut -d " " -f 2 >> scan_files
+rsync -aiz --ignore-existing \
+	--include="*/" \
+	--include="*i386" \
+	--include="*amd64" \
+	--include="*x86-64*" \
+	--exclude "isos" \
+	--exclude="*" \
+	$DISTRO ./packages | egrep '^>' | cut -d " " -f 2 >> scan_files
 
 # Sort the files to be hashed
 sort -u scan_files > scn

--- a/measurementDB/downloadPkgs.sh
+++ b/measurementDB/downloadPkgs.sh
@@ -28,13 +28,15 @@ CENTOS="rsync://anorien.csc.warwick.ac.uk/CentOS/7/"
 # Default distro to sync is Debian
 DISTRO=$DEBIAN
 
-rsync -aiz --ignore-existing \
+rsync --archive --itemize-changes --compress --ignore-existing \
 	--include="*/" \
 	--include="*i386" \
 	--include="*amd64" \
 	--include="*x86-64*" \
-	--exclude "isos" \
-	--exclude="*" \
+	--include="*x86_64*" \
+	--include="*.deb" \
+	--include="*.rpm" \
+	--exclude "*" \
 	$DISTRO ./packages | egrep '^>' | cut -d " " -f 2 >> scan_files
 
 # Sort the files to be hashed

--- a/measurementDB/insertDB.sh
+++ b/measurementDB/insertDB.sh
@@ -26,7 +26,8 @@ PACK=$(mktemp -p ./)
 VER=$(mktemp -p ./)
 LIST=$(mktemp -p ./)
 
-grep -v "da39a3ee5e6b4b0d3255bfef95601890afd80709" ./shaLog > $LIST
+# Don't insert null hashes into the database
+grep --invert-match "da39a3ee5e6b4b0d3255bfef95601890afd80709" ./shaLog > $LIST
 
 cat $LIST | cut -d " " -f 3 | cut -d "@" -f 2 | cut -d "_" -f 1 > $PACK
 cat $LIST | cut -d " " -f 3 | cut -d "@" -f 2 | cut -d "_" -f 2 > $VER

--- a/measurementDB/storeHash.sh
+++ b/measurementDB/storeHash.sh
@@ -23,7 +23,9 @@
 
 computeHash(){
 	TEMP=$(mktemp -d --tmpdir=./$TDIR)
-	dpkg -x ../packages/$1 $TEMP
+	# If not a Debian package then try RPM
+	>&2 echo "Currently in $PWD, going to copy ../packages/$1, heading to $PWD/$TEMP"
+	dpkg -x ../packages/$1 $TEMP >/dev/null 2>&1 || cd $PWD/$TEMP && rpm2cpio ../../packages/$1 | cpio -idm >/dev/null 2>&1
 	cd $TEMP
 	find ./ -type f ! -empty | sed '/^\s*$/d' | xargs file | egrep -i "ELF|script" | \
 		cut -d ":" -f 1 | xargs sha1sum | sed "s/$/@$(basename $1 | sed -e 's/[\/&]/\\&/g')/g"

--- a/measurementDB/storeHash.sh
+++ b/measurementDB/storeHash.sh
@@ -23,8 +23,17 @@
 
 computeHash(){
 	TEMP=$(mktemp -d --tmpdir=./$TDIR)
-	dpkg -x ../packages/$1 $TEMP
-	cd $TEMP
+	# If not a Debian package then try RPM
+	#>&2 echo "Currently in $PWD, going to copy ../packages/$1, heading to $PWD/$TEMP"
+	dpkg -x ../packages/$1 $TEMP >/dev/null 2>&1 || cd $PWD/$TEMP && rpm2cpio ../../packages/$1 | cpio -idm >/dev/null 2>&1
+	if [ $? -gt 0 ];
+	then
+		>&2 echo "$1 failed" > ../../pkgs.failed
+		exit 1
+	else
+		>&2 echo "$1 succeeded"
+	fi
+	cd $TEMP >/dev/null 2>&1
 	find ./ -type f ! -empty | sed '/^\s*$/d' | xargs file | egrep -i "ELF|script" | \
 		cut -d ":" -f 1 | xargs sha1sum | sed "s/$/@$(basename $1 | sed -e 's/[\/&]/\\&/g')/g"
 	cd ..

--- a/measurementDB/storeHash.sh
+++ b/measurementDB/storeHash.sh
@@ -16,8 +16,8 @@
 # Authors:	Victor Sallard
 #		Adrian L. Shaw <adrianlshaw@acm.org>
 #
-# This script will find the debian packages, unpack them,
-# hash the executables and store the hash in Redis.
+# This script will find DEB and RPM packages, unpack them,
+# hash the executables and store the hashes in a file called shaLog.
 # It will also keep track of the already hashed packages
 # and store their name in a file
 

--- a/measurementDB/storeHash.sh
+++ b/measurementDB/storeHash.sh
@@ -24,9 +24,16 @@
 computeHash(){
 	TEMP=$(mktemp -d --tmpdir=./$TDIR)
 	# If not a Debian package then try RPM
-	>&2 echo "Currently in $PWD, going to copy ../packages/$1, heading to $PWD/$TEMP"
+	#>&2 echo "Currently in $PWD, going to copy ../packages/$1, heading to $PWD/$TEMP"
 	dpkg -x ../packages/$1 $TEMP >/dev/null 2>&1 || cd $PWD/$TEMP && rpm2cpio ../../packages/$1 | cpio -idm >/dev/null 2>&1
-	cd $TEMP
+	if [ $? -gt 0 ];
+	then
+		>&2 echo "$1 failed" > ../../pkgs.failed
+		exit 1
+	else
+		>&2 echo "$1 succeeded"
+	fi
+	cd $TEMP >/dev/null 2>&1
 	find ./ -type f ! -empty | sed '/^\s*$/d' | xargs file | egrep -i "ELF|script" | \
 		cut -d ":" -f 1 | xargs sha1sum | sed "s/$/@$(basename $1 | sed -e 's/[\/&]/\\&/g')/g"
 	cd ..


### PR DESCRIPTION
This merge makes the package downloader more generic in order to support verifying RPM distributions like CentOS. Still need to make ra-agent compatible on CentOS 7.