### PR TITLE
CI with Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,11 @@
 sudo: required
-dist: jessie
-
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y netcat-traditional tpm-tools libtspi-dev git autoconf redis-server redis-tools 
-  - cd tpm-quote-tools 
-  - autoreconf -i
-  - ./configure
-  - sudo make install 
-  - cd ..
-
-language: bash
-script: bash tests/test-script.sh
 
 services:
-  - redis-server
+  - docker
+
+language: bash
+
+before_install:
+  - docker build -t test .
+
+script: docker run test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM debian:jessie
 WORKDIR /testsite/
 RUN apt-get -qq update
-RUN apt-get install -y git make gcc netcat-traditional tpm-tools libtspi-dev git autoconf redis-server redis-tools
+RUN apt-get install -y -qq git make gcc netcat-traditional vim-common tpm-tools \
+	    libtspi-dev git autoconf redis-server redis-tools
+COPY . /testsite/ 
+RUN git submodule init && git submodule update
 RUN cd tpm-quote-tools && autoreconf -i
-COPY . 
-RUN ./configure
-RUN make install
-RUN cd ..
+RUN cd tpm-quote-tools && ./configure
+RUN cd tpm-quote-tools && make install
 ENTRYPOINT ["bash", "tests/test-script.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM debian:jessie
+WORKDIR /testsite/
+RUN apt-get -qq update
+RUN apt-get install -y git make gcc netcat-traditional tpm-tools libtspi-dev git autoconf redis-server redis-tools
+RUN cd tpm-quote-tools && autoreconf -i
+COPY . 
+RUN ./configure
+RUN make install
+RUN cd ..
+ENTRYPOINT ["bash", "tests/test-script.sh"]


### PR DESCRIPTION
Although LightVerifier requests for Debian 8 from Travis CI, it doesn't seem to be the case anymore. Rather than rely on Travis to provision the right host, it is worth moving the problem into a container. I have invested some time in a Dockerfile, which will allow the LightVerifier to be tested on any host. 

The CI test only checks that nothing broke the behaviour of the code. It does not test the TPM or the associated tools. The next step is to be able to provide the right Docker commands to give enough privileges for the TPM TSS to access the host TPM. Theoretically, this should allow LightVerifier to run on any host with a TPM. I will add it to the README when this is complete. 