### PR TITLE
Added tool to read the registered information for a given host

### DIFF
--- a/read-registration.sh
+++ b/read-registration.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# (c) Copyright 2018 Adrian L. Shaw <adrianlshaw@acm.org>
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License, version 2, as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+if [ $# -eq 0 ]; then
+	echo "read_registration <hostname>>"
+	exit 1;
+fi
+
+REDIS_AIK_INFO=15
+REDIS_AIK_DB=13
+HASHAIK=$(redis-cli --raw -n $REDIS_AIK_DB get "$1")
+
+echo "AIK hash: $HASHAIK"
+echo "Boot aggregate: $(redis-cli --raw -n $REDIS_AIK_INFO LINDEX "$HASHAIK" '0' | base64 -d)"
+echo "PCR10: $(redis-cli --raw -n $REDIS_AIK_INFO LINDEX "$HASHAIK" '2' | base64 -d)"
+echo "Reflog (base64): $(redis-cli --raw -n $REDIS_AIK_INFO LINDEX "$HASHAIK" '1')"


### PR DESCRIPTION
Example output:

```sh
0 user@machine:~/LightVerifier> ./read-registration.sh localhost
AIK hash: d1fcc09712b0f303f1ca574fc4aedc87c7d53316
Boot aggregate: 10 fb4eaece00bda2fd79a9e4603414cb09a4988b1b ima-ng sha1:df88aa15a9a76c95693691f203330a48cf513394 boot_aggregate
PCR10: 1FF21701901079C5D38D6389E482E5546308F0AF
Reflog (base64): ADZRVVQyAAAAAAAAAAAAAAAAAAAA/wAAAAAAAwAEAAHhBgjdZ18w5ikKuvTqQ7XZ2GUkCQ==
```